### PR TITLE
v2023.7.1 update

### DIFF
--- a/Nickvision.GirExt/GdkExt/Clipboard.cs
+++ b/Nickvision.GirExt/GdkExt/Clipboard.cs
@@ -29,9 +29,9 @@ public static partial class GdkExt
                 var stringHandle = Gdk.Internal.Clipboard.ReadTextFinish(sourceObject.Handle, res.Handle, out var error);
                 if (!error.IsInvalid)
                 {
-                    throw new Exception(error.ToString() ?? "");
+                    tcs.SetException(new Exception(error.ToString() ?? ""));
                 }
-                if (stringHandle.IsInvalid)
+                else if (stringHandle.IsInvalid)
                 {
                     tcs.SetResult(null);
                 }

--- a/Nickvision.GirExt/GdkExt/Helpers.cs
+++ b/Nickvision.GirExt/GdkExt/Helpers.cs
@@ -1,0 +1,55 @@
+using System.Runtime.InteropServices;
+
+namespace Nickvision.GirExt;
+
+/// <summary>
+/// Extensions for classes in Gdk namespace
+/// </summary>
+public static partial class GdkExt
+{
+    [LibraryImport("gtk", StringMarshalling = StringMarshalling.Utf8)] // Using "gdk" doesn't work here for some reason
+    [return: MarshalAs(UnmanagedType.I1)]
+    private static partial bool gdk_rgba_parse(out RGBA rgba, string spec);
+    
+    /// <summary>
+    /// Helper RGBA struct. Used instead of Gdk.RGBA
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RGBA
+    {
+        /// <summary>
+        /// Red channel (0.0-1.0)
+        /// </summary>
+        public float Red;
+        /// <summary>
+        /// Green channel (0.0-1.0)
+        /// </summary>
+        public float Green;
+        /// <summary>
+        /// Blue channel (0.0-1.0)
+        /// </summary>
+        public float Blue;
+        /// <summary>
+        /// Alpha channel (0.0-1.0)
+        /// </summary>
+        public float Alpha;
+
+        /// <summary>
+        /// Helper method to parse color string to GdkExt.RGBA struct
+        /// </summary>
+        /// <param name="colorRGBA">Struct to write to</param>
+        /// <param name="spec">Color string</param>
+        /// <returns>Whether or not the string was parsed successfully</returns>
+        public static bool Parse(out RGBA? colorRGBA, string spec)
+        {
+            Resolver.SetResolver();
+            if(gdk_rgba_parse(out var val, spec))
+            {
+                colorRGBA = val;
+                return true;
+            }
+            colorRGBA = null;
+            return false;
+        }
+    }
+}

--- a/Nickvision.GirExt/GtkExt/ColorDialog.cs
+++ b/Nickvision.GirExt/GtkExt/ColorDialog.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace Nickvision.GirExt;
+
+/// <summary>
+/// Extensions for classes in Gtk namespace
+/// </summary>
+public static partial class GtkExt {
+    /// <summary>
+    /// Extension method for Gtk.ColorDialog to choose a color
+    /// </summary>
+    /// <param name="dialog">Color dialog</param>
+    /// <param name="parent">Parent window</param>
+    /// <exception cref="Exception">Thrown if failed to choose a color</exception>
+    /// <returns>Color struct if successful, or null</returns>
+    public static Task<GdkExt.RGBA?> ChooseRgbaAsync(this Gtk.ColorDialog dialog, Gtk.Window parent)
+    {
+        var tcs = new TaskCompletionSource<GdkExt.RGBA?>();
+
+        var callback = new Gio.Internal.AsyncReadyCallbackAsyncHandler((sourceObject, res, data) =>
+        {
+            if (sourceObject is null)
+            {
+                tcs.SetException(new Exception("Missing source object"));
+            }
+            else
+            {
+                var color = Gtk.Internal.ColorDialog.ChooseRgbaFinish(sourceObject.Handle, res.Handle, out var error);
+                if (!error.IsInvalid)
+                {
+                    tcs.SetException(new Exception(error.ToString() ?? ""));
+                }
+                else if (color.DangerousGetHandle() == IntPtr.Zero)
+                {
+                    tcs.SetResult(null);
+                }
+                else
+                {
+                    tcs.SetResult(Marshal.PtrToStructure<GdkExt.RGBA>(color.DangerousGetHandle()));
+                }
+            }
+        });
+
+        Gtk.Internal.ColorDialog.ChooseRgba(
+            self: dialog.Handle,
+            parent: parent.Handle,
+            initialColor: new Gdk.Internal.RGBAOwnedHandle(IntPtr.Zero),
+            cancellable: IntPtr.Zero,
+            callback: callback.NativeCallback,
+            userData: IntPtr.Zero
+            );
+        
+        return tcs.Task;
+    }
+}

--- a/Nickvision.GirExt/GtkExt/ColorDialog.cs
+++ b/Nickvision.GirExt/GtkExt/ColorDialog.cs
@@ -7,7 +7,8 @@ namespace Nickvision.GirExt;
 /// <summary>
 /// Extensions for classes in Gtk namespace
 /// </summary>
-public static partial class GtkExt {
+public static partial class GtkExt
+{
     /// <summary>
     /// Extension method for Gtk.ColorDialog to choose a color
     /// </summary>

--- a/Nickvision.GirExt/GtkExt/FileDialog.cs
+++ b/Nickvision.GirExt/GtkExt/FileDialog.cs
@@ -30,9 +30,9 @@ public static partial class GtkExt
                 var fileValue = Gtk.Internal.FileDialog.OpenFinish(sourceObject.Handle, res.Handle, out var error);
                 if (!error.IsInvalid)
                 {
-                    throw new Exception(error.ToString() ?? "");
+                    tcs.SetException(new Exception(error.ToString() ?? ""));
                 }
-                if (fileValue == IntPtr.Zero)
+                else if (fileValue == IntPtr.Zero)
                 {
                     tcs.SetResult(null);
                 }
@@ -77,9 +77,9 @@ public static partial class GtkExt
                 var listValue = Gtk.Internal.FileDialog.OpenMultipleFinish(sourceObject.Handle, res.Handle, out var error);
                 if (!error.IsInvalid)
                 {
-                    throw new Exception(error.ToString() ?? "");
+                    tcs.SetException(new Exception(error.ToString() ?? ""));
                 }
-                if (listValue == IntPtr.Zero)
+                else if (listValue == IntPtr.Zero)
                 {
                     tcs.SetResult(null);
                 }
@@ -124,9 +124,9 @@ public static partial class GtkExt
                 var fileValue = Gtk.Internal.FileDialog.SaveFinish(sourceObject.Handle, res.Handle, out var error);
                 if (!error.IsInvalid)
                 {
-                    throw new Exception(error.ToString() ?? "");
+                    tcs.SetException(new Exception(error.ToString() ?? ""));
                 }
-                if (fileValue == IntPtr.Zero)
+                else if (fileValue == IntPtr.Zero)
                 {
                     tcs.SetResult(null);
                 }
@@ -171,9 +171,9 @@ public static partial class GtkExt
                 var fileValue = Gtk.Internal.FileDialog.SelectFolderFinish(sourceObject.Handle, res.Handle, out var error);
                 if (!error.IsInvalid)
                 {
-                    throw new Exception(error.ToString() ?? "");
+                    tcs.SetException(new Exception(error.ToString() ?? ""));
                 }
-                if (fileValue == IntPtr.Zero)
+                else if (fileValue == IntPtr.Zero)
                 {
                     tcs.SetResult(null);
                 }
@@ -218,9 +218,9 @@ public static partial class GtkExt
                 var listValue = Gtk.Internal.FileDialog.SelectMultipleFoldersFinish(sourceObject.Handle, res.Handle, out var error);
                 if (!error.IsInvalid)
                 {
-                    throw new Exception(error.ToString() ?? "");
+                    tcs.SetException(new Exception(error.ToString() ?? ""));
                 }
-                if (listValue == IntPtr.Zero)
+                else if (listValue == IntPtr.Zero)
                 {
                     tcs.SetResult(null);
                 }

--- a/Nickvision.GirExt/GtkExt/FileLauncher.cs
+++ b/Nickvision.GirExt/GtkExt/FileLauncher.cs
@@ -30,7 +30,8 @@ public static partial class GtkExt
                 var launchValue = Gtk.Internal.FileLauncher.LaunchFinish(sourceObject.Handle, res.Handle, out var error);
                 if (!error.IsInvalid)
                 {
-                    throw new Exception(error.ToString() ?? "");
+                    tcs.SetException(new Exception(error.ToString() ?? ""));
+                    return;
                 }
                 tcs.SetResult(launchValue);
             }
@@ -70,7 +71,8 @@ public static partial class GtkExt
                 var launchValue = Gtk.Internal.FileLauncher.OpenContainingFolderFinish(sourceObject.Handle, res.Handle, out var error);
                 if (!error.IsInvalid)
                 {
-                    throw new Exception(error.ToString() ?? "");
+                    tcs.SetException(new Exception(error.ToString() ?? ""));
+                    return;
                 }
                 tcs.SetResult(launchValue);
             }

--- a/Nickvision.GirExt/GtkExt/Helpers.cs
+++ b/Nickvision.GirExt/GtkExt/Helpers.cs
@@ -17,12 +17,34 @@ public unsafe static partial class GtkExt
     }
 
     [LibraryImport("gtk")]
+    private static partial void gtk_color_dialog_button_set_rgba(nint button, ref GdkExt.RGBA rgba);
+    [LibraryImport("gtk")]
     private static partial GLibList* gtk_list_box_get_selected_rows(nint box);
     [LibraryImport("gtk")]
     private static partial int gtk_list_box_row_get_index(nint row);
-    [LibraryImport("gtk")]
-    private static partial void gtk_color_dialog_button_set_rgba(nint button, ref GdkExt.RGBA rgba);
-    
+
+    /// <summary>
+    /// Helper extension method for Gtk.ColorButton to get color as GdkExt.RGBA
+    /// </summary>
+    /// <param name="button">Color button</param>
+    /// <returns>Color as GdkExt.RGBA</returns>
+    public static GdkExt.RGBA GetExtRgba(this Gtk.ColorDialogButton button)
+    {
+        Gdk.RGBA gdkColor = button.GetRgba();
+        return Marshal.PtrToStructure<GdkExt.RGBA>(gdkColor.Handle.DangerousGetHandle());
+    }
+
+    /// <summary>
+    /// Helper extension method for Gtk.ColorButton to set color as GdkExt.RGBA
+    /// </summary>
+    /// <param name="button">Color button</param>
+    /// <param name="color">Color as GdkExt.RGBA</param>
+    public static void SetExtRgba(this Gtk.ColorDialogButton button, GdkExt.RGBA color)
+    {
+        Resolver.SetResolver();
+        gtk_color_dialog_button_set_rgba(button.Handle, ref color);
+    }
+
     /// <summary>
     /// Helper extension method for Gtk.ListBox to get indices of selected row
     /// </summary>
@@ -38,17 +60,5 @@ public unsafe static partial class GtkExt
             list.Add(gtk_list_box_row_get_index(ptr->data));
         }
         return list;
-    }
-
-    public static GdkExt.RGBA GetExtRgba(this Gtk.ColorDialogButton button)
-    {
-        Gdk.RGBA gdkColor = button.GetRgba();
-        return Marshal.PtrToStructure<GdkExt.RGBA>(gdkColor.Handle.DangerousGetHandle());
-    }
-
-    public static void SetExtRgba(this Gtk.ColorDialogButton button, GdkExt.RGBA color)
-    {
-        Resolver.SetResolver();
-        gtk_color_dialog_button_set_rgba(button.Handle, ref color);
     }
 }

--- a/Nickvision.GirExt/GtkExt/Helpers.cs
+++ b/Nickvision.GirExt/GtkExt/Helpers.cs
@@ -20,6 +20,8 @@ public unsafe static partial class GtkExt
     private static partial GLibList* gtk_list_box_get_selected_rows(nint box);
     [LibraryImport("gtk")]
     private static partial int gtk_list_box_row_get_index(nint row);
+    [LibraryImport("gtk")]
+    private static partial void gtk_color_dialog_button_set_rgba(nint button, ref GdkExt.RGBA rgba);
     
     /// <summary>
     /// Helper extension method for Gtk.ListBox to get indices of selected row
@@ -36,5 +38,17 @@ public unsafe static partial class GtkExt
             list.Add(gtk_list_box_row_get_index(ptr->data));
         }
         return list;
+    }
+
+    public static GdkExt.RGBA GetExtRgba(this Gtk.ColorDialogButton button)
+    {
+        Gdk.RGBA gdkColor = button.GetRgba();
+        return Marshal.PtrToStructure<GdkExt.RGBA>(gdkColor.Handle.DangerousGetHandle());
+    }
+
+    public static void SetExtRgba(this Gtk.ColorDialogButton button, GdkExt.RGBA color)
+    {
+        Resolver.SetResolver();
+        gtk_color_dialog_button_set_rgba(button.Handle, ref color);
     }
 }

--- a/Nickvision.GirExt/GtkExt/UriLauncher.cs
+++ b/Nickvision.GirExt/GtkExt/UriLauncher.cs
@@ -30,7 +30,8 @@ public static partial class GtkExt
                 var launchValue = Gtk.Internal.UriLauncher.LaunchFinish(sourceObject.Handle, res.Handle, out var error);
                 if (!error.IsInvalid)
                 {
-                    throw new Exception(error.ToString() ?? "");
+                    tcs.SetException(new Exception(error.ToString() ?? ""));
+                    return;
                 }
                 tcs.SetResult(launchValue);
             }

--- a/Nickvision.GirExt/Nickvision.GirExt.csproj
+++ b/Nickvision.GirExt/Nickvision.GirExt.csproj
@@ -14,7 +14,12 @@
     <Copyright>(c) Nickvision 2021-2023</Copyright>
     <PackageProjectUrl>https://nickvision.org</PackageProjectUrl>
     <RepositoryUrl>https://github.com/NickvisionApps/Aura</RepositoryUrl>
-    <PackageReleaseNotes>- Improved internal storage of callbacks</PackageReleaseNotes>
+    <PackageReleaseNotes>
+        - Added ColorDialog functions
+        - Added Gdk.RGBA helpers
+        - Added OpenMultiple and SelectMultiple functions for FileDialog
+        - Improved internal storage of callbacks
+    </PackageReleaseNotes>
     <PackageIcon>logo-r.png</PackageIcon>
   </PropertyGroup>
 

--- a/Nickvision.GirExt/Resolver.cs
+++ b/Nickvision.GirExt/Resolver.cs
@@ -42,16 +42,18 @@ public static class Resolver
         {
             filename = libraryName switch
             {
+                "gdk" => "libgdk-3-0.dll",
                 "gtk" => "libgtk-4-1.dll",
-                _ => ""
+                _ => libraryName
             };
         }
         else
         {
             filename = libraryName switch
             {
+                "gdk" => "libgdk-3.so.0",
                 "gtk" => "libgtk-4.so.1",
-                _ => ""
+                _ => libraryName
             };
         }
         _libraries[libraryName] = NativeLibrary.Load(filename, assembly, searchPath);

--- a/README.md
+++ b/README.md
@@ -13,17 +13,27 @@ Currently implemented:
 * Gdk
   * Clipboard
     * ReadTextAsync
+  * Helpers<sup>[1]</sup>
+    * GdkExt.RGBA
+      * Parse
 * Gtk
+  * ColorDialog
+    * ChooseRgbaAsync
   * FileDialog
     * OpenAsync
+    * OpenMultipleAsync
     * SaveAsync
     * SelectFolderAsync
+    * SelectMultipleFoldersAsync
   * FileLauncher
     * LaunchAsync
     * OpenContainingFolderAsync
   * UriLauncher
     * LaunchAsync
   * Helpers<sup>[1]</sup>
+    * ColorDialog
+      * GetExtRgba
+      * SetExtRgba
     * ListBox
       * GetSelectedRowsIndices
 * External<sup>[2]</sup>


### PR DESCRIPTION
Today's Cavalier release was unexpected to me, so yeah, here we are, making a new release of the library the next day after previous one! 😄 

Some notes:

* `GdkExt.RGBA` is a replacement for Gdk.RGBA since the latter doesn't contain color channels fields
* `Parse` is inside GdkExt.RGBA (GdkExt.RGBA.Parse) to be closer to gdk/gir.core API (Gdk.RGBA.Parse)
* Exceptions should not be thrown from Async, there's no way to catch them, `tcs.SetException` is now used everywhere